### PR TITLE
fix: Instana module identification is wrong

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function isStyleImport(module) {
 }
 
 function isInstanaModule(module) {
-    return module.startsWith('in-') && (module.indexOf('/') > 0);
+    return module.startsWith('in-');
 }
 
 function descending(first, second) {


### PR DESCRIPTION
# Why

All Instana modules are prefixed with `in-` – no slash required!

# What

Remove the slash requirement. Tried in a local VSCode instance.

Fixes #2